### PR TITLE
Allow backslashes in placeholder defaults

### DIFF
--- a/autoload/neocomplcache/sources/snippets_complete.vim
+++ b/autoload/neocomplcache/sources/snippets_complete.vim
@@ -769,7 +769,7 @@ function! s:expand_placeholder(start, end, holder_cnt, line)"{{{
         \ s:get_placeholder_marker_default_pattern(),
         \ '\\d\\+', a:holder_cnt, '')
   let default = substitute(
-        \ matchstr(current_line, default_pattern), '\\\ze.', '', 'g')
+        \ matchstr(current_line, default_pattern), '\\\ze[^\\]', '', 'g')
   " Substitute marker.
   let default = substitute(default,
         \ s:get_placeholder_marker_substitute_pattern(),


### PR DESCRIPTION
I managed to put a backslash in a placeholder default, by escaping it like \, and then changing this pattern.

I've no idea how safe it is, the placeholder in a placeholders still seem to work, but I don't know if it will have messed anything else up.
