### PR TITLE
Fixed the lacking 'options head' specifier in the example of the help.

### DIFF
--- a/doc/neosnippet.txt
+++ b/doc/neosnippet.txt
@@ -425,6 +425,7 @@ Snippet Keywords:
 
 >
 	snippet     if
+	options     head
 	  if ${1:condition}
 	     ${2}
 	  endif


### PR DESCRIPTION
ヘルプの"SNIPPET SYNTAX"セクション、"options"キーワードの"head"オプション項目の例に"options head"が出てきてないですけれど、多分こういう事ですよね?
