### PR TITLE
fix C++ namespace snippet

### DIFF
--- a/autoload/neosnippet/snippets/cpp.snip
+++ b/autoload/neosnippet/snippets/cpp.snip
@@ -44,7 +44,7 @@ delete      namespace
 snippet     namespace
 abbr        namespace {}
 options     head
-    namespace ${1:#:name}
+    namespace ${1:#:name} {
         ${0:TARGET}
     } // namespace $1
 


### PR DESCRIPTION
namespace の開き括弧が抜けていたため，修正しました．
