### PR TITLE
Fixed javascript snip.

### DIFF
--- a/autoload/neosnippet/snippets/javascript.snip
+++ b/autoload/neosnippet/snippets/javascript.snip
@@ -66,4 +66,4 @@ options word
 
 snippet setTimeout-function
 options head
-  setTimeout(function() {${0}}, ${1:10});
+  setTimeout(function() { ${0} }, ${1:10});


### PR DESCRIPTION
他スニペット(snippet f)との統一と、headタイプの補完が効くようにするため、スペースを追加しました。
