### PR TITLE
Improve Javascript snip.

### DIFF
--- a/autoload/neosnippet/snippets/javascript.snip
+++ b/autoload/neosnippet/snippets/javascript.snip
@@ -67,3 +67,7 @@ options word
 snippet setTimeout-function
 options head
   setTimeout(function() { ${0} }, ${1:10});
+
+snippet cl
+options head
+  console.log(${0:#:output});


### PR DESCRIPTION
`g:neosnippet#snippets_directory`でvim-snippets/snippetsを取り込んでいたのですが、 https://github.com/Shougo/neosnippet.vim/issues/150 にあるようにneosnippet側で定義したものを上書きしてしまうので、同等のsnippetを追記しました。

他のsnippetについては同等のものが既に定義されていたり、使用頻度が（自分の場合）低いため、`console.log`のみにしていますが、どこまで記述するかは難しいですね
