### PR TITLE
Changed behavior of b:undo_ftplugin

### DIFF
--- a/ftplugin/snippet.vim
+++ b/ftplugin/snippet.vim
@@ -29,6 +29,8 @@ set cpo&vim
 
 if !exists('b:undo_ftplugin')
     let b:undo_ftplugin = ''
+else
+    let b:undo_ftplugin = '|'
 endif
 
 setlocal expandtab
@@ -37,7 +39,7 @@ let &l:softtabstop=&tabstop
 let &l:commentstring="#%s"
 
 let b:undo_ftplugin .= '
-    \ | setlocal expandtab< shiftwidth< softtabstop< tabstop< commentstring<
+    \ setlocal expandtab< shiftwidth< softtabstop< tabstop< commentstring<
     \'
 
 let &cpo = s:save_cpo

--- a/indent/snippet.vim
+++ b/indent/snippet.vim
@@ -35,6 +35,8 @@ set cpo&vim
 
 if !exists('b:undo_indent')
     let b:undo_indent = ''
+else
+    let b:undo_indent = '|'
 endif
 
 setlocal indentexpr=SnippetsIndent()
@@ -54,7 +56,7 @@ function! SnippetsIndent() "{{{
 endfunction"}}}
 
 let b:undo_indent .= '
-    \ | setlocal indentexpr<
+    \ setlocal indentexpr<
     \'
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
僕の環境では、NeoSnippetEdit時に望ましくない挙動がするので修正しました。

![変な挙動](http://gifzo.net/BKAG7uLcDG4.gif)

snipファイルを開いたときに、カーソル行 + カーソル行後?の内容がechoされてしまいます。
今回送ったpull-requestの内容で修正されました。Vimの仕様としても、今回送ったものの方が正しいかなと思ったのですが、どうなのでしょう。
