### PR TITLE
Added save_xxx snippets

### DIFF
--- a/autoload/neosnippet/snippets/vim.snip
+++ b/autoload/neosnippet/snippets/vim.snip
@@ -183,4 +183,25 @@ abbr    lua <<EOF | EOF
     ${0}
     EOF
 
+snippet save_pos
+options head
+abbr    use pos save
+    let pos_save = getpos('.')
+    ${0}
+    call setpos('.', pos_save)
 
+snippet save_register
+options head
+abbr    use register save
+    let save_reg_$1 = getreg('${1}')
+    let save_regtype_$1 = getregtype('$1')
+    ${0}
+    call setreg('$1', save_reg_$1, save_regtype_$1)
+
+snippet save_option
+options head
+abbr    use option save
+    let $1_save = &${1}
+    let &$1 = ${2}
+    ${0}
+    let &$1 = $1_save


### PR DESCRIPTION
カーソル位置やレジスタやオプションの値を一時的に退避させる処理は Vim script を書いているとよくあるので，スニペットにしてみました．しばらく使ってみてなかなか便利なので提案します．

以下は実際に挿入されるスニペットの例です．

``` vim
    let pos_save = getpos('.')

    call setpos('.', pos_save)
```

　

``` vim
    let save_reg_g = getreg('g')
    let save_regtype_g = getregtype('g')

    call setreg('g', save_reg_g, save_regtype_g)
```

　

``` vim
    let selection_save = &selection
    let &selection =

    let &selection = selection_save
```
