### PR TITLE
Fixes SID_PREFIX bug

### DIFF
--- a/autoload/neosnippet/mappings.vim
+++ b/autoload/neosnippet/mappings.vim
@@ -162,7 +162,7 @@ function! s:snippets_jump_or_expand(cur_text, col) "{{{
 endfunction"}}}
 
 function! s:SID_PREFIX() "{{{
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\ze\w\+$')
 endfunction"}}}
 
 function! s:trigger(function) "{{{


### PR DESCRIPTION
`expand('<sfile>')` が関数の中で呼び出したとき呼び出しのスタックコール的なものに展開されるので、正しく SID を取得出来ていません。

``` vim
inoremap <expr> <TAB> <SID>super_tab_completion()

function! s:super_tab_completion()
   " ここで呼び出したい
endfunction
```
