### PR TITLE
fix: folding markerが含まれるsnippetで他の窓のfoldingが閉じられる問題

### DIFF
--- a/autoload/neosnippet/view.vim
+++ b/autoload/neosnippet/view.vim
@@ -93,10 +93,10 @@ function! neosnippet#view#_expand(cur_text, col, trigger_name) "{{{
   let expand_stack = neosnippet#variables#expand_stack()
 
   try
-    call setline('.', snippet_lines[0])
     if len(snippet_lines) > 1
       call append('.', snippet_lines[1:])
     endif
+    call setline('.', snippet_lines[0])
 
     if begin_line != end_line || snippet.options.indent
       call s:indent_snippet(begin_line, end_line)


### PR DESCRIPTION
1行目に`{{{`などのfolding markerが含まれ、2行目以降に`}}}`などの閉じ記号を持つsnippetを展開した場合、
もし同一バッファを他の窓で開いているならば、他の窓では初めに1行目が出力されたときに`{{{`の閉じ記号によって、
カーソル行以降が閉じられてしまう。

その後、`}}}`が出力されて、folding markerが意図通りになるが、そのとき他窓で起きることは、
以前開かれていた折り畳み情報の喪失である。
snippet出力前に開いていたカーソル行以降の折り畳みは、全て閉じられてしまう（レベルが上の折り畳みを除く）。

もし、setline()とappend()の処理の順に必然性がないのであれば、
2行目以降をappend()してから1行目をsetline()するように変更していただけないだろうか？
