### PR TITLE
Fixing typos in unite sources.

### DIFF
--- a/autoload/unite/sources/neosnippet.vim
+++ b/autoload/unite/sources/neosnippet.vim
@@ -1,5 +1,5 @@
 "=============================================================================
-" FILE: snippet.vim
+" FILE: neosnippet.vim
 " AUTHOR:  Shougo Matsushita <Shougo.Matsu@gmail.com>
 " Last Modified: 31 Dec 2013.
 " License: MIT license  {{{
@@ -146,7 +146,7 @@ function! unite#sources#neosnippet#start_complete() "{{{
     return ''
   endif
 
-  return unite#start_complete(['snippet'],
+  return unite#start_complete(['neosnippet'],
         \ { 'input': neosnippet#util#get_cur_text(), 'buffer_name' : '' })
 endfunction "}}}
 

--- a/autoload/unite/sources/neosnippet_target.vim
+++ b/autoload/unite/sources/neosnippet_target.vim
@@ -1,5 +1,5 @@
 "=============================================================================
-" FILE: snippet_target.vim
+" FILE: neosnippet_target.vim
 " AUTHOR:  Shougo Matsushita <Shougo.Matsu@gmail.com>
 " Last Modified: 31 Dec 2013.
 " License: MIT license  {{{


### PR DESCRIPTION
Looks like a couple things got missed when renaming snippet to neosnippet (eafef3c2d3262821ba601887c544424d21a793e4). One of these partially broke unite support.
