### PR TITLE
Escape ampersand in mirror text

### DIFF
--- a/autoload/neosnippet/view.vim
+++ b/autoload/neosnippet/view.vim
@@ -435,7 +435,7 @@ function! s:substitute_placeholder_marker(start, end, snippet_holder_cnt) "{{{
       if getline(line) =~ sync_marker
         let sub = escape(matchstr(getline(line),
               \ substitute(neosnippet#get_sync_placeholder_marker_default_pattern(),
-              \ '\\d\\+', cnt, '')), '/\')
+              \ '\\d\\+', cnt, '')), '/\&')
         silent execute printf('%d,%ds/\m' . mirror_marker . '/%s/'
           \ . (&gdefault ? '' : 'g'), a:start, a:end, sub)
         call setline(line, substitute(getline(line), sync_marker, sub, ''))


### PR DESCRIPTION
Without this change, there is unexpected behavior when the inserted text includes an ampersand and there the marker has one or more mirrors. I noticed it in a C snippet when I entered `&foo` in a placeholder and got `foofoo`, then `foofoofoo`, etc. after `<Plug>(neosnippet_expand_or_jump)`.
