### PR TITLE
*feature) 添加uppercase函数。

### DIFF
--- a/autoload/neosnippet/view.vim
+++ b/autoload/neosnippet/view.vim
@@ -247,6 +247,13 @@ function! neosnippet#view#_search_snippet_range(start, end, cnt, ...) "{{{
     return 1
   endfor
 
+  for linenum in range(a:start, a:end)
+    let tmp_line = getline(linenum)
+    let tmp_line = substitute(tmp_line, '\v\%uc\(([^)]+)\)', '\U\1\E', 'g')
+    let tmp_line = substitute(tmp_line, '\v\%ucfirst\(([^)]+)\)', '\u\1', 'g')
+    call setline(linenum, tmp_line)
+  endfor
+
   return 0
 endfunction"}}}
 function! s:search_outof_range(col) "{{{


### PR DESCRIPTION
add uppercase function %uc and %ucfirst to snippet.
It is very useful, details in 
https://github.com/jarijokinen/snipmate.vim
http://stackoverflow.com/questions/5064430/changing-the-case-within-snipmate-vim-snippets