### PR TITLE
Add optional '#:' to target marker pattern

### DIFF
--- a/autoload/neosnippet.vim
+++ b/autoload/neosnippet.vim
@@ -76,7 +76,7 @@ endfunction"}}}
 
 " Get marker patterns.
 function! neosnippet#get_placeholder_target_marker_pattern() "{{{
-  return '\${\d\+:TARGET\%(:.\{-}\)\?\\\@<!}'
+  return '\${\d\+:\(#:\)\?TARGET\%(:.\{-}\)\?\\\@<!}'
 endfunction"}}}
 function! neosnippet#get_placeholder_marker_pattern() "{{{
   return '<`\d\+\%(:.\{-}\)\?\\\@<!`>'


### PR DESCRIPTION
I updated the pattern to match target placeholders so snippets that use, for example, `${0:#:TARGET}` work with `<Plug>(neosnippet_start_unite_snippet)`.