### PR TITLE
Shorten the neosnippet mark to [ns]

### DIFF
--- a/rplugin/python3/deoplete/sources/neosnippet.py
+++ b/rplugin/python3/deoplete/sources/neosnippet.py
@@ -31,7 +31,7 @@ class Source(Base):
         Base.__init__(self, vim)
 
         self.name = 'neosnippet'
-        self.mark = '[nsnip]'
+        self.mark = '[ns]'
         self.rank = 200
 
     def gather_candidates(self, context):


### PR DESCRIPTION
`[ns]` communicates that the completion came from neosnippet just as well as `[nsnip]` and is three characters shorter!