### PR TITLE
Let other plugins better integrate with `g:neosnippet#enable_completed_snippet`

### DIFF
--- a/autoload/neosnippet/parser.vim
+++ b/autoload/neosnippet/parser.vim
@@ -301,6 +301,10 @@ endfunction"}}}
 function! neosnippet#parser#_get_completed_snippet(completed_item, next_text) abort "{{{
   let item = a:completed_item
 
+  if has_key(item, "snippet")
+    return item.snippet
+  endif
+
   " Set abbr
   let abbr = (item.abbr != '') ? item.abbr : item.word
   if len(item.menu) > 5

--- a/test/functions.vim
+++ b/test/functions.vim
@@ -128,5 +128,10 @@ function! s:suite.get_completed_snippet() abort
         \ 'word' : 'for[', 'abbr' : '',
         \ 'menu' : '', 'info' : ''
         \ }, ''), '${1}]${2}')
+
+  call s:assert.equals(neosnippet#parser#_get_completed_snippet({
+        \ 'word' : 'something', 'abbr' : 'something(else)',
+        \ 'menu' : '', 'info' : '', 'snippet' : '(${1:custom})${2}'
+        \ }, ''), '(${1:custom})${2}')
 endfunction
 


### PR DESCRIPTION
Current implementation does a lot of assumptions about the format of the completion to convert it into a snippet. It's very fragile as any unexpected element in the text breaks the conversion and it's limited as well as it only supports C-like kind of functions.

My idea, with this PR, is to let other plugins to provide the snippet as an extra key in the `completed_item` dictionary. These plugins commonly are language-specific so the know a lot more about the proper snippet that should be used.

The change is backward compatible as it only looks at a brand new key and doesn't change anything related to the text-to-snippet transformation. Also, this new key doesn't hurt as it is totally ignored by other plugins and even by vim itself.

Hope it make sense for you guys as it would make my life a lot easier now that I'm trying to improve __ensime-vim__ completion functionality.

Thank you for such amazing plugins.
Cheers. 