### PR TITLE
Use shiftwidth()

### DIFF
--- a/autoload/neosnippet/view.vim
+++ b/autoload/neosnippet/view.vim
@@ -200,7 +200,7 @@ function! s:indent_snippet(begin, end) abort "{{{
         if &l:expandtab && current_line =~ '^\t\+'
           " Expand tab.
           cal setline('.', substitute(current_line,
-                \ '^\t\+', base_indent . repeat(' ', &shiftwidth *
+                \ '^\t\+', base_indent . repeat(' ', shiftwidth() *
                 \    len(matchstr(current_line, '^\t\+'))), ''))
         elseif line_nr != a:begin
           call setline('.', base_indent . current_line)

--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -48,7 +48,7 @@ function! SnippetsIndent() abort "{{{
     if prev_line =~ '^\s*$'
         return 0
     elseif prev_line =~ '^' . syntax && line !~ '^\s*' . syntax
-        return &shiftwidth
+        return shiftwidth()
     else
         return match(line, '\S')
     endif


### PR DESCRIPTION
I set shiftwidth=0 because shiftwidth=0 have following feature.

```
'shiftwidth' 'sw' number  (default 8)
      local to buffer
  Number of spaces to use for each step of (auto)indent.  Used for
  |'cindent'|, |>>|, |<<|, etc.
  When zero the 'ts' value will be used.  Use the |shiftwidth()|
  function to get the effective shiftwidth value.
```

And this is help for shiftwidth().

```
 shiftwidth()            *shiftwidth()*
    Returns the effective value of 'shiftwidth'. This is the
    'shiftwidth' value unless it is zero, in which case it is the
    'tabstop' value.  This function was introduced with patch
    7.3.694 in 2012, everybody should have it by now.
```

Using shiftwidth() is convenient for users who set shiftwidth=0.