### PR TITLE
Reset indent if the line starts with syntax

### DIFF
--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -74,11 +74,11 @@ function! SnippetsIndent() abort "{{{
 endfunction"}}}
 
 function! s:is_empty(line)
-    return a:line =~ '\v^\s*$'
+    return a:line =~ '^\s*$'
 endfunction
 
 function! s:is_syntax(line)
-    return a:line =~ '\v^\s*%(snippet|abbr|prev_word|alias|options|regexp)\s'
+    return a:line =~ '^\s*\%(snippet\|abbr\|prev_word\|alias\|options\|regexp\)\s'
 endfunction
 
 let &cpo = s:save_cpo

--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -46,7 +46,7 @@ let b:undo_indent .= 'setlocal
 
 setlocal indentexpr=SnippetsIndent()
 setlocal autoindent
-setlocal indentkeys=o,O,=include\ ,=snippet\ ,=abbr\ ,=prev_word\ ,=delete\ ,=alias\ ,=options\ ,=regexp\ ,!^F
+setlocal indentkeys=o,O,=abbr\ ,=prev_word\ ,=alias\ ,=options\ ,=regexp\ ,!^F
 
 function! SnippetsIndent() abort "{{{
     let line = getline('.')
@@ -78,7 +78,7 @@ function! s:is_empty(line)
 endfunction
 
 function! s:is_syntax(line)
-    return a:line =~ '\v^\s*%(include|snippet|abbr|prev_word|delete|alias|options|regexp)\s'
+    return a:line =~ '\v^\s*%(snippet|abbr|prev_word|alias|options|regexp)\s'
 endfunction
 
 let &cpo = s:save_cpo

--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -35,28 +35,51 @@ set cpo&vim
 if !exists('b:undo_indent')
     let b:undo_indent = ''
 else
-    let b:undo_indent = '|'
+    let b:undo_indent .= '|'
 endif
 
+let b:undo_indent .= 'setlocal
+    \ indentexpr<
+    \ autoindent<
+    \ indentkeys<
+    \'
+
 setlocal indentexpr=SnippetsIndent()
+setlocal autoindent
+setlocal indentkeys=o,O,=include\ ,=snippet\ ,=abbr\ ,=prev_word\ ,=delete\ ,=alias\ ,=options\ ,=regexp\ ,!^F
 
 function! SnippetsIndent() abort "{{{
     let line = getline('.')
     let prev_line = (line('.') == 1)? '' : getline(line('.')-1)
-    let syntax = '\%(include\|snippet\|abbr\|prev_word\|delete\|alias\|options\|regexp\)'
 
-    if prev_line =~ '^\s*$'
+    if s:is_empty(prev_line)
         return 0
-    elseif prev_line =~ '^' . syntax && line !~ '^\s*' . syntax
-        return shiftwidth()
+    endif
+
+    "for indentkeys o,O
+    if s:is_empty(line)
+        if s:is_syntax(prev_line)
+            return shiftwidth()
+        else
+            return -1
+        endif
+    "for indentkeys =words
     else
-        return match(line, '\S')
+        if s:is_syntax(line) && s:is_syntax(prev_line)
+            return 0
+        else
+            return -1
+        endif
     endif
 endfunction"}}}
 
-let b:undo_indent .= '
-    \ setlocal indentexpr<
-    \'
+function! s:is_empty(line)
+    return a:line =~ '\v^\s*$'
+endfunction
+
+function! s:is_syntax(line)
+    return a:line =~ '\v^\s*%(include|snippet|abbr|prev_word|delete|alias|options|regexp)\s'
+endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
note: | is cursor
```
snippet a
    options|
```
type space, then above code become
```
snippet a
options |
```