### PR TITLE
Reset indent if the line starts with syntax

### DIFF
--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -35,28 +35,48 @@ set cpo&vim
 if !exists('b:undo_indent')
     let b:undo_indent = ''
 else
-    let b:undo_indent = '|'
+    let b:undo_indent .= '|'
 endif
 
+setlocal autoindent
 setlocal indentexpr=SnippetsIndent()
+setlocal indentkeys=o,O,=abbr\ ,=prev_word\ ,=alias\ ,=options\ ,=regexp\ ,!^F
+
+let b:undo_indent .= 'setlocal
+    \ autoindent<
+    \ indentexpr<
+    \ indentkeys<
+    \'
 
 function! SnippetsIndent() abort "{{{
     let line = getline('.')
     let prev_line = (line('.') == 1)? '' : getline(line('.')-1)
-    let syntax = '\%(include\|snippet\|abbr\|prev_word\|delete\|alias\|options\|regexp\)'
+    let syntax = '\%(include\|snippet\|abbr\|prev_word\|delete\|alias\|options\|regexp\)\s'
+    let defining = '\%(snippet\|abbr\|prev_word\|alias\|options\|regexp\)\s'
 
-    if prev_line =~ '^\s*$'
-        return 0
-    elseif prev_line =~ '^' . syntax && line !~ '^\s*' . syntax
-        return shiftwidth()
+    "for indentkeys o,O
+    if s:is_empty(line)
+        if s:is_empty(prev_line)
+            return 0
+        elseif prev_line =~ '^' . defining
+            return shiftwidth()
+        else
+            return -1
+        endif
+
+    "for indentkeys =words
     else
-        return match(line, '\S')
+        if line =~ '^\s*' . syntax
+            return 0
+        else
+            return -1
+        endif
     endif
 endfunction"}}}
 
-let b:undo_indent .= '
-    \ setlocal indentexpr<
-    \'
+function! s:is_empty(line)
+    return a:line =~ '^\s*$'
+endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/indent/neosnippet.vim
+++ b/indent/neosnippet.vim
@@ -40,7 +40,7 @@ endif
 
 setlocal autoindent
 setlocal indentexpr=SnippetsIndent()
-setlocal indentkeys=o,O,=abbr\ ,=prev_word\ ,=alias\ ,=options\ ,=regexp\ ,!^F
+setlocal indentkeys=o,O,=include\ ,=snippet\ ,=abbr\ ,=prev_word\ ,=delete\ ,=alias\ ,=options\ ,=regexp\ ,!^F
 
 let b:undo_indent .= 'setlocal
     \ autoindent<
@@ -56,9 +56,7 @@ function! SnippetsIndent() abort "{{{
 
     "for indentkeys o,O
     if s:is_empty(line)
-        if s:is_empty(prev_line)
-            return 0
-        elseif prev_line =~ '^' . defining
+        if prev_line =~ '^' . defining
             return shiftwidth()
         else
             return -1
@@ -67,6 +65,8 @@ function! SnippetsIndent() abort "{{{
     "for indentkeys =words
     else
         if line =~ '^\s*' . syntax
+           \ && (s:is_empty(prev_line)
+                \ || prev_line =~ '^' . defining)
             return 0
         else
             return -1


### PR DESCRIPTION
note: | is cursor
```
snippet a
    options|
```
type space, then above code become
```
snippet a
options |
```