### PR TITLE
Add arguments_are_optional variable

### DIFF
--- a/autoload/neosnippet.vim
+++ b/autoload/neosnippet.vim
@@ -23,6 +23,8 @@ call neosnippet#util#set_default(
       \ 'g:neosnippet#enable_completed_snippet', 0,
       \ 'g:neosnippet#enable_complete_done')
 call neosnippet#util#set_default(
+      \ 'g:neosnippet#arguments_are_optional', 1)
+call neosnippet#util#set_default(
       \ 'g:neosnippet#enable_auto_clear_markers', 1)
 call neosnippet#util#set_default(
       \ 'g:neosnippet#completed_pairs', {})

--- a/autoload/neosnippet.vim
+++ b/autoload/neosnippet.vim
@@ -23,7 +23,7 @@ call neosnippet#util#set_default(
       \ 'g:neosnippet#enable_completed_snippet', 0,
       \ 'g:neosnippet#enable_complete_done')
 call neosnippet#util#set_default(
-      \ 'g:neosnippet#arguments_are_optional', 1)
+      \ 'g:neosnippet#enable_optional_arguments', 1)
 call neosnippet#util#set_default(
       \ 'g:neosnippet#enable_auto_clear_markers', 1)
 call neosnippet#util#set_default(

--- a/autoload/neosnippet/parser.vim
+++ b/autoload/neosnippet/parser.vim
@@ -339,9 +339,7 @@ function! neosnippet#parser#_get_completed_snippet(completed_item, cur_text, nex
     for arg in split(substitute(
           \ neosnippet#parser#_get_in_paren('<', '>', abbr),
           \ '<\zs.\{-}\ze>', '', 'g'), '[^[]\zs\s*,\s*')
-      let args .= printf('${%d:#:%s%s}',
-            \ cnt, ((args != '') ? ', ' : ''),
-            \ escape(arg, '{}'))
+      let args .= neosnippet#parser#_conceal_argument(arg, cnt, args)
       let cnt += 1
     endfor
     let snippet .= args
@@ -362,9 +360,7 @@ function! neosnippet#parser#_get_completed_snippet(completed_item, cur_text, nex
       continue
     endif
 
-    let args .= printf('${%d:#:%s%s}',
-          \ cnt, ((args != '') ? ', ' : ''),
-          \ escape(arg, '{}'))
+    let args .= neosnippet#parser#_conceal_argument(arg, cnt, args)
     let cnt += 1
   endfor
   let snippet .= args
@@ -406,4 +402,16 @@ function! neosnippet#parser#_get_in_paren(key, pair, str) abort "{{{
   return ''
 endfunction"}}}
 
+function! neosnippet#parser#_conceal_argument(arg, cnt, args) abort "{{{
+  let outside = ''
+  let inside = ''
+  if (a:args != '')
+    if g:neosnippet#arguments_are_optional
+      let inside = ', '
+    else
+      let outside = ', '
+    endif
+  endif
+  return printf('%s${%d:#:%s%s}', outside, a:cnt, inside, escape(a:arg, '{}'))
+endfunction"}}}
 " vim: foldmethod=marker

--- a/autoload/neosnippet/parser.vim
+++ b/autoload/neosnippet/parser.vim
@@ -406,7 +406,7 @@ function! neosnippet#parser#_conceal_argument(arg, cnt, args) abort "{{{
   let outside = ''
   let inside = ''
   if (a:args != '')
-    if g:neosnippet#arguments_are_optional
+    if g:neosnippet#enable_optional_arguments
       let inside = ', '
     else
       let outside = ', '

--- a/doc/neosnippet.txt
+++ b/doc/neosnippet.txt
@@ -217,12 +217,14 @@ g:neosnippet#enable_completed_snippet
 
 		The default value is 0.
 		
-					*g:neosnippet#arguments_are_optional*
-g:neosnippet#arguments_are_optional
-		If this variable is not 0, neosnippet expanded function
-		arguments will conceal commas.
+					*g:neosnippet#enable_optional_arguments*
+g:neosnippet#enable_optional_arguments
+		If this variable is not 0, neosnippet will conceal commas in
+		expanded arguments from completed snippets.
 		
 		Useful for languages where arguments are optional by default.
+
+		Note: For use with |g:neosnippet#enable_completed_snippet| = 1
 
 		The default value is 1.
 

--- a/doc/neosnippet.txt
+++ b/doc/neosnippet.txt
@@ -216,6 +216,15 @@ g:neosnippet#enable_completed_snippet
 		prototype.
 
 		The default value is 0.
+		
+					*g:neosnippet#arguments_are_optional*
+g:neosnippet#arguments_are_optional
+		If this variable is not 0, neosnippet expanded function
+		arguments will conceal commas.
+		
+		Useful for languages where arguments are optional by default.
+
+		The default value is 1.
 
 					*g:neosnippet#enable_auto_clear_markers*
 g:neosnippet#enable_auto_clear_markers


### PR DESCRIPTION
If arguments are optional by default (in javascript for example) it makes sense for commas to be concealed such that if you exit the completion prematurely you are not left with a bunch of useless commas. However, for languages where arguments are not optional (rust for example) it is annoying to have to type in commas manually. 

This PR adds a variable to toggle this, defaulting to on in order to maintain the current behavior (although I feel that off makes more sense for the majority of languages).

**`g:arguments_are_optional = 1`:**
![2017-06-16_23-20-06](https://user-images.githubusercontent.com/9101614/27249737-5d9af960-52ea-11e7-88ed-a7262fd866a5.gif)

**`g:arguments_are_optional = 0`:**
![2017-06-16_23-07-02](https://user-images.githubusercontent.com/9101614/27249723-21541cfc-52ea-11e7-919d-64619efbfaf5.gif)


