### PR TITLE
Ignore rust self argument when completing methods

### DIFF
--- a/autoload/neosnippet/parser.vim
+++ b/autoload/neosnippet/parser.vim
@@ -357,7 +357,9 @@ function! neosnippet#parser#_get_completed_snippet(completed_item, cur_text, nex
         \ neosnippet#parser#_get_in_paren(key, pair, abbr),
         \ key.'\zs.\{-}\ze'.pair . '\|<\zs.\{-}\ze>', '', 'g'),
         \ '[^[]\zs\s*,\s*')
-    if key ==# '(' && arg ==# 'self' && &filetype ==# 'python'
+    if key ==# '(' && (
+          \ (&filetype ==# 'python' && arg ==# 'self') ||
+          \ (&filetype ==# 'rust' && arg =~# '\m^&\?\(mut \)\?self$'))
       " Ignore self argument
       continue
     endif


### PR DESCRIPTION
Like python, in rust `self` as the first argument of a function means it is a method. Unlike python, self can be moved (`self`), borrowed (`&self`), or mutably borrowed (`&mut self`). 

This PR makes the completed snippet ignore the self arguments in rust, the same way it ignores them in python. 