### PR TITLE
Fix c snippets expanded in cpp filetype

### DIFF
--- a/autoload/neosnippet/helpers.vim
+++ b/autoload/neosnippet/helpers.vim
@@ -178,7 +178,7 @@ function! s:get_sources_filetypes(filetype) abort "{{{
         \ exists('*context_filetype#get_filetypes') ?
         \   context_filetype#get_filetypes(a:filetype) :
         \ split(((a:filetype == '') ? 'nothing' : a:filetype), '\.')
-  return neosnippet#util#uniq(['_', a:filetype] + filetypes)
+  return neosnippet#util#uniq(['_'] + filetypes + [a:filetype])
 endfunction"}}}
 
 " vim: foldmethod=marker


### PR DESCRIPTION
C++のソースコードで `inc<TAB>` とすると，`#include <iostream>` と展開されるはずが `#include <stdio.h>` に展開されました．