### PR TITLE
Use execute() instead of :redir

### DIFF
--- a/autoload/neosnippet/mappings.vim
+++ b/autoload/neosnippet/mappings.vim
@@ -33,9 +33,7 @@ function! neosnippet#mappings#_clear_select_mode_mappings() abort
     return
   endif
 
-  redir => mappings
-    silent! smap
-  redir END
+  let mappings = execute('smap', 'silent!')
 
   for map in map(filter(split(mappings, '\n'),
         \ "v:val !~# '^s' && v:val !~# '^\\a*\\s*<\\S\\+>'"),


### PR DESCRIPTION
In my environment, this function is called from execute().

```
Error detected while processing function neosnippet#mappings#_clear_select_mode_mappings:
line    5:
E930: Cannot use :redir inside execute()
```

I didn't check in detail though, I confirmed that execute() is implemented before Vim 8.0.
Generally speaking, execute() is better than `:redir`.