### PR TITLE
Try to fix trigger when completing LSP snippet

### DIFF
--- a/autoload/neosnippet/mappings.vim
+++ b/autoload/neosnippet/mappings.vim
@@ -187,7 +187,7 @@ function! s:get_user_data(cur_text) abort
     let lspitem = user_data.lspitem
     if has_key(lspitem, 'textEdit') && type(lspitem.textEdit) == v:t_dict
       let snippet = lspitem.textEdit.newText
-      let snippet_trigger = lspitem.textEdit.newText
+      let snippet_trigger = v:completed_item.word
     elseif get(lspitem, 'insertTextFormat', -1) == 2
       let snippet = lspitem.insertText
       let snippet_trigger = lspitem.insertText


### PR DESCRIPTION
This tries to fix an issue I found while using rust-analyzer in conjuction with LanguageClient-neovim, deoplete and neosnippet.

The behavior I observe is:
1. When cycling through the items, this setup fills in the shortened (`label`?) version of the completion item, e.g. `bar(…)` in my case, resulting in a line `_foo.bar(…)`.
2. When completion is done (e.g. on pressing a char like `;`), LanguageClient proceeds with the full text edit. When neosnippet is enabled, this inserts a snippet like `bar(${1:baz}, ${2:quux})$0` and neosnippet tries to expand / delete manually entered part of the item. However, it acts on the full snippet, unaware that the current line only contained `bar(…)` and thus deletes a much longer suffix of the line (according to the entire snippet).

I "fixed" this by instead treating `v:completed_item.word` as `snippet_trigger`, which contains the right suffix to delete: `bar(…)`.

I tested that this fixes the issue with rust-analyzer and does not seem to break other language servers, specifically `clangd` and `pyls`.

Note that I barely know VimL and LSP, so I arrived at this fix through sheer bruteforce. Please feel free to suggest any ways to improve the solution.

See the original issue in `rust-analyzer` repo for demonstration https://github.com/rust-analyzer/rust-analyzer/issues/3991

Note that this code has previously been touched by another PR that also mentioned rust-analyzer: https://github.com/Shougo/neosnippet.vim/issues/487. I do not yet understand what the implications are.