### PR TITLE
If lspitem.insertText does not exist, use lspitem.label

### DIFF
--- a/autoload/neosnippet/mappings.vim
+++ b/autoload/neosnippet/mappings.vim
@@ -195,7 +195,7 @@ function! s:get_user_data(cur_text) abort
       let snippet = lspitem.textEdit.newText
       let has_lspitem = v:true
     elseif get(lspitem, 'insertTextFormat', -1) == 2
-      let snippet = lspitem.insertText
+      let snippet = get(lspitem, 'insertText', lspitem.label)
       let has_lspitem = v:true
     endif
   elseif get(user_data, 'snippet', '') !=# ''


### PR DESCRIPTION
I have encountered that errors are thrown when used with LanguageClient-neovim and [typescript-language-server](https://github.com/theia-ide/typescript-language-server) due to the fact it sends `CompletionItem` without `insertText` attribute, only with `label`. Related: https://github.com/theia-ide/typescript-language-server/issues/130

```
function add(x: number, y: number): number {
    return x + y;
}

add(
```

```
Error detected while processing function neosnippet#complete_done[1]..neosnippet#mappings#_complete_done[1]..<SNR>
100_get_completed_snippets[6]..<SNR>100_get_user_data:                                                            
line   23:                                                                                                        
E716: Key not present in Dictionary: insertText
```

[Langserver specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion) says this about `CompletionItem.insertText`:

```
* A string that should be inserted into a document when selecting
* this completion. When `falsy` the label is used.
```

The fix in this PR should account for these cases.