### PR TITLE
[doc] Remove `regexp` that does not work equally to `options head`

### DIFF
--- a/doc/neosnippet.txt
+++ b/doc/neosnippet.txt
@@ -485,14 +485,6 @@ Snippet Keywords:
 >
 	regexp '^% '
 <
-	This snippet works same as "options head".
->
-	snippet     if
-	regexp     '^\s*'
-	    if ${1:condition}
-	      ${2}
-	    endif
-<
 - options [options] (Optional)
 
 	Options influence the snippet behavior. The possible values are:


### PR DESCRIPTION
The following snippet does not work equally to `options head`
```
snippet     if
regexp     '^\s*'
    if ${1:condition}
      ${2}
    endif
```
Namely, the snippet can be triggered for
```
x if
```